### PR TITLE
Add hex and ramp properties

### DIFF
--- a/src/properties.lua
+++ b/src/properties.lua
@@ -62,6 +62,24 @@ local props = {
       Min  = 1,
       Max = 50,
       Value = 4
+  },
+
+  {
+      Name = "Application Hex",
+      Type = "text",
+      Value = "00"
+  },
+  {
+      Name = "Address Hex",
+      Type = "text",
+      Value = "00"
+  },
+  {
+      Name = "Ramp Rate",
+      Type = "integer",
+      Min = 0,
+      Max = 255,
+      Value = 0
   }
 
 }

--- a/src/rectify_properties.lua
+++ b/src/rectify_properties.lua
@@ -6,3 +6,24 @@ props["Preset Recall Mode"].IsHidden = props["Protocol"].Value ~= "DyNet 1"
 -- if props["DyNet Protocol"].Value == "Text" then
 --   props["Connection Type"].Value = "TCP"
 -- end
+
+-- ensure hex properties are valid two digit values
+local function validate_hex(prop)
+    local value = tostring(prop.Value or "00"):upper()
+    local num = tonumber(value, 16)
+    if not num then
+        value = "00"
+    else
+        value = string.format("%02X", math.max(0, math.min(255, num)))
+    end
+    prop.Value = value
+end
+
+validate_hex(props["Application Hex"])
+validate_hex(props["Address Hex"])
+
+-- clamp ramp rate within range
+local ramp = tonumber(props["Ramp Rate"].Value) or 0
+if ramp < 0 then ramp = 0 end
+if ramp > 255 then ramp = 255 end
+props["Ramp Rate"].Value = ramp


### PR DESCRIPTION
## Summary
- add new properties for `Application Hex`, `Address Hex`, and `Ramp Rate`
- validate the new property values in `rectify_properties.lua`

## Testing
- `lua` executable not found; unable to run Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_6857581c1f5483259d1f6105e840895d